### PR TITLE
Merge Skip feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ METAQ_MAX_NODES=${METAQ_NODES}  # Integers that puts an upper size limit on jobs
 METAQ_MAX_GPUS=${METAQ_GPUS}    # If the main loop decides that there were no possible jobs, it will double these maximal
                                 # values and loop again.  It will only concede that there are truly no possible jobs when
                                 # these maximal values max out at METAQ_NODES and METAQ_GPUS respectively.
+METAQ_SORT_TASKS=sort           # How to sort the result of finding tasks.
+                                # A good choice can be shuf, the command-line utility that shuffles input lines.
+METAQ_SKIP_ON_STOLEN=false      # {false,directory,reset}, what to do if a task is stolen.
+                                #     On directory, break out of this directory and proceed to the next one.
+                                #     On reset, begin the loop over METAQ_TASK_FOLDERS again.
+                                #     On false, or anything else, just look at the next task.
 
 
 # ANYTHING ELSE YOU WANT TO DO BEFORE LAUNCHING.
@@ -273,25 +279,28 @@ Finally, you can set up a task that could run on different machines that seem th
 
 `METAQ` provides a number of small accessories to see what's going on.  
 
+#### `x/current [optionalMachineArgument]`
+Reports which jobs are in the working directory, machine-by-machine unless a machine is provided.  The first column is the `machine/job`, the second is how many are currently working, the last is how many log files in total there are.
+
 #### `x/status`
 Reports based on tasks' PROJECT flag what's in the `METAQ/{priority,todo,hold}` folders.
 
 #### `x/running`
 Reports the current status of jobs in the working folder.  This only works if you have set up
 
-#### `x/reset machineArgument`
+#### `x/reset machineArgument`; `x/abandon machineArgument`
 WARNING WARNING WARNING
 
 SERIOUSLY
 
 HANDLE WITH CARE!
-    
-If your queue contains only work for one machine, this is perfectly fine.  
-However, if `METAQ_JOB_RUNNING` (see below on interacting with the batch scheduler) could potentially miss the existence of a job then this command can wreck havoc.
-This script looks in the `working/${machineArgument}` directory, and looks for abandoned work.
-If it finds work for a `METAQ_JOB_ID` that is no longer running, it moves the task scripts into the `METAQ/priority` folder and deletes the `METAQ/working/${machineArgument}/METAQ_JOB_ID` folder.
 
-`x/reset` will compare `$HOSTNAME` to `^${machineArgument}.*$`.  If there's a match, the assumption is that running `x/reset` is probably OK.  If there's a mismatch, the user will get a warning and prompted for confirmation.
+If your queue contains only work for one machine, this is perfectly fine.  
+However, if `METAQ_JOB_RUNNING` (see below on interacting with the batch scheduler) could potentially miss the existence of a job then these commands can wreck havoc.
+These scripts look in the `working/${machineArgument}` directory for jobs that are no longer running.
+If it finds work for a `METAQ_JOB_ID` that is no longer running, `x/abandon` deletes the `METAQ/working/${machineArgument}/METAQ_JOB_ID` folder, `x/reset` moves the task scripts into the `METAQ/priority` folder first.
+
+`x/{abandon,reset}` will compare `$HOSTNAME` to `^${machineArgument}.*$`.  If there's a match, the assumption is that running `x/reset` is probably OK.  If there's a mismatch, the user will get a warning and prompted for confirmation.
 
 
 ## INTERACTING WITH THE BATCH SCHEDULER
@@ -333,6 +342,7 @@ You can perform a bare-bones test from the `METAQ` directory by running `x/demo.
 
 Some of the accessory scripts detect their own location on disk and infer what METAQ they belong to.  These include:
 
+- [ ] x/current
 - [ ] x/report
 - [ ] x/reset
 - [ ] x/running

--- a/x/launch.sh
+++ b/x/launch.sh
@@ -87,6 +87,9 @@ fi
 if [[ -z "$METAQ_SORT_TASKS" ]]; then
     METAQ_SORT_TASKS="sort"
 fi
+if [[ -z "$METAQ_SKIP_ON_STOLEN" ]]; then
+    METAQ_SKIP_ON_STOLEN="false"
+fi
 
 ############################
 ############################ GET METAQ LIBRARY
@@ -441,12 +444,28 @@ while $METAQ_LOOP_TASKS_REMAIN || $METAQ_LOOP_FOREVER; do
             if [[ "${METAQ_ATTEMPT_RESULT}" == "LAUNCHED" ]]; then
                 METAQ_LAUNCH_SUCCESS=true
             fi
+            if [[ "${METAQ_ATTEMPT_RESULT}" == "STOLEN" ]]; then
+                if [[ "${METAQ_SKIP_ON_STOLEN}" == "directory" || "${METAQ_SKIP_ON_STOLEN}" == "reset" ]]; then
+                    METAQ_PRINT 2 "Since the task was stolen, skipping ${METAQ_SKIP_ON_STOLEN}"
+                    break; # from the loop over tasks
+                fi
+            fi
             if [[ (! "${METAQ_ATTEMPT_RESULT}" == "CLOCK") && (! "${METAQ_ATTEMPT_RESULT}" == "IMPOSSIBLE") ]]; then
                 METAQ_LOOP_TASKS_REMAIN=true
             fi
             sleep 1 #so that launched subprocesses have time to start.
         done
+        
+        # If we broke out of the directory, should we go back to priority tasks?
+        if [[ "${METAQ_ATTEMPT_RESULT}" == "STOLEN" && "${METAQ_SKIP_ON_STOLEN}" == "reset" ]]; then
+            METAQ_LOOP_TASKS_REMAIN=true    # We don't actually know---we have to loop again to decide if there are any tasks remaining.
+            break; # from the loop over METAQ_TASK_FOLDERS
+        fi
     done
+    
+    if [[ "${METAQ_ATTEMPT_RESULT}" == "STOLEN" && "${METAQ_SKIP_ON_STOLEN}" == "reset" ]]; then
+        continue; # the main while loop.
+    fi
     
     if [[ ! $METAQ_LAUNCHES -lt $METAQ_MAX_LAUNCHES ]]; then 
         echo "Launched maximum number of tasks: ${METAQ_LAUNCHES}."

--- a/x/launch.sh
+++ b/x/launch.sh
@@ -464,6 +464,7 @@ while $METAQ_LOOP_TASKS_REMAIN || $METAQ_LOOP_FOREVER; do
     done
     
     if [[ "${METAQ_ATTEMPT_RESULT}" == "STOLEN" && "${METAQ_SKIP_ON_STOLEN}" == "reset" ]]; then
+        METAQ_ATTEMPT_RESULT="RESET"
         continue; # the main while loop.
     fi
     

--- a/x/run.llnl.sh
+++ b/x/run.llnl.sh
@@ -18,7 +18,7 @@ METAQ_JOB_ID=${SLURM_JOB_ID}    # Any string.  You don't have to use the batch s
                                 # but you should ensure that the METAQ_JOB_ID is unique.
 METAQ_NODES=${SLURM_NNODES}     # Integer, which should be less than or equal to the nodes specified to the batch scheduler.
                                 # But if it's less than, you're guaranteeing you're wasting resources.
-METAQ_RUN_TIME=43200              # Seconds, should match the above walltime=15:00.
+METAQ_RUN_TIME=43200            # Seconds, should match the above walltime=12:00:00.
                                 # You may also specify times in the format for the #METAQ MIN_WC_TIME flag, [[HH:]MM:]SS.
 METAQ_MACHINE=machine           # Any string. Right now doesn't do anything, but it could in the future!
                                 # Would interact with METAQ MACHINE flag.
@@ -31,7 +31,7 @@ METAQ_TASK_FOLDERS=(            # A bash array of priority-ordered absolute path
     $METAQ/priority             # This allows a user to segregate tasks and order their importance based on any number of 
     $METAQ/todo                 # metrics.  Our original use was to separate tasks by nodes, so that we could waste as little
     )                           # time as possible looking for a "big" task.
-METAQ_GPUS=$[ METAQ_NODES * 1 ] # An integer describing how many GPUs are allocated to this job.
+METAQ_GPUS=0                    # An integer describing how many GPUs are allocated to this job.
                                 # How many GPUs to specify is a bit of a subtle business.  See METAQ/README.txt for more discussion.
 METAQ_MAX_LAUNCHES=1048576      # An integer that limits the number of tasks that can be successfully launched.  Default is 2^20, essentially infinite.
 METAQ_LOOP_FOREVER=false        # Bash booleans {true,false}.  Should you run out the wall clock?
@@ -40,9 +40,23 @@ METAQ_LOOP_FOREVER=false        # Bash booleans {true,false}.  Should you run ou
 METAQ_SLEEPY_TIME=3             # Number of seconds to sleep before repeating the main task-attempting loop.
 METAQ_VERBOSITY=2               # How much detail do you want to see?
                                 # Levels of detail are offset by tabbing 4 spaces.
+METAQ_SIMULTANEOUS_TASKS=1048576 # An integer that limits how many tasks can run concurrently.
+                                 # Some environments limit how many simultaneous tasks you can submit.  For example,
+                                 # [on Titan, users are artificially limited to 100 simultaneous aprun processes](https://www.olcf.ornl.gov/kb_articles/using-the-aprun-command/).
+METAQ_MIN_NODES=0               # Integers that puts a lower size limit on jobs.
+METAQ_MIN_GPUS=0                # If the main loop decides that there were no possible jobs, it will halve these minimal
+                                # values and loop again.  It will only concede that there are truly no possible jobs when
+                                # these minimal values are <= 1.
+METAQ_MAX_NODES=${METAQ_NODES}  # Integers that puts an upper size limit on jobs.
+METAQ_MAX_GPUS=${METAQ_GPUS}    # If the main loop decides that there were no possible jobs, it will double these maximal
+                                # values and loop again.  It will only concede that there are truly no possible jobs when
+                                # these maximal values max out at METAQ_NODES and METAQ_GPUS respectively.
 METAQ_SORT_TASKS=sort           # How to sort the result of finding tasks.
                                 # A good choice can be shuf, the command-line utility that shuffles input lines.
-
+METAQ_SKIP_ON_STOLEN=false      # {false,directory,reset}, what to do if a task is stolen.
+                                #     On directory, break out of this directory and proceed to the next one.
+                                #     On reset, begin the loop over METAQ_TASK_FOLDERS again.
+                                #     On false, or anything else, just look at the next task.
 
 # ANYTHING ELSE YOU WANT TO DO BEFORE LAUNCHING.
 # For example, you can have this script resubmit itself.

--- a/x/run.pbs.sh
+++ b/x/run.pbs.sh
@@ -48,6 +48,11 @@ METAQ_MAX_GPUS=${METAQ_GPUS}    # If the main loop decides that there were no po
                                 # these maximal values max out at METAQ_NODES and METAQ_GPUS respectively.
 METAQ_SORT_TASKS=sort           # How to sort the result of finding tasks.
                                 # A good choice can be shuf, the command-line utility that shuffles input lines.
+METAQ_SKIP_ON_STOLEN=false      # {false,directory,reset}, what to do if a task is stolen.
+                                #     On directory, break out of this directory and proceed to the next one.
+                                #     On reset, begin the loop over METAQ_TASK_FOLDERS again.
+                                #     On false, or anything else, just look at the next task.
+
 
 # ANYTHING ELSE YOU WANT TO DO BEFORE LAUNCHING.
 # For example, you can have this script resubmit itself.

--- a/x/run.slurm.sh
+++ b/x/run.slurm.sh
@@ -48,6 +48,11 @@ METAQ_MAX_GPUS=${METAQ_GPUS}    # If the main loop decides that there were no po
                                 # these maximal values max out at METAQ_NODES and METAQ_GPUS respectively.
 METAQ_SORT_TASKS=sort           # How to sort the result of finding tasks.
                                 # A good choice can be shuf, the command-line utility that shuffles input lines.
+METAQ_SKIP_ON_STOLEN=false      # {false,directory,reset}, what to do if a task is stolen.
+                                #     On directory, break out of this directory and proceed to the next one.
+                                #     On reset, begin the loop over METAQ_TASK_FOLDERS again.
+                                #     On false, or anything else, just look at the next task.
+
 
 # ANYTHING ELSE YOU WANT TO DO BEFORE LAUNCHING.
 # For example, you can have this script resubmit itself.


### PR DESCRIPTION
Setting `METAQ_SKIP_ON_STOLEN` causes mq to either go to the next `directory` or `reset`s, going back to the first directory, rebuilding the list of tasks for that directory in either case.