### PR TITLE
try using fully qualified domain name, hostname -f, to match METAQ_MA…

### DIFF
--- a/x/abandon
+++ b/x/abandon
@@ -30,9 +30,9 @@ if [[ ! -d ${METAQ_WORKING} ]]; then
 fi
 
 MACHINE_MATCH='^'"$METAQ_MACHINE"'.*$'
-if [[ ! "$HOSTNAME" =~ $MACHINE_MATCH ]]; then
-
-    echo "You are on machine                                $HOSTNAME"
+#if [[ ! "`hostname -f`" =~ $MACHINE_MATCH ]]; then
+if [[ ! "`hostname -f`" == *$METAQ_MACHINE* ]]; then
+    echo "You are on machine                                `hostname -f`"
     echo "You intend to abandon tasks as though you are on  $METAQ_MACHINE"
     echo ""
     echo "If these don't match, you might cause yourself a headache."


### PR DESCRIPTION
…CHINE

`hostname -f` returns the fully qualified domain name, rather than the names like `login15`.  Using the FQDN and modifying the match condition from 

```
if [[ ! "`hostname -f`" =~ $MACHINE_MATCH ]]; then
```
to
```
[[ ! "`hostname -f`" == *$METAQ_MACHINE* ]]; then
```
allows for example
```
x/abandon perlmutter
```
to work without raising the warning about HOSTNAME not matching METAQ_MACHINE.  I'm not sure I've thought through all potential pitfalls with the modified string matching, but I think it is safe.